### PR TITLE
Add metadata support

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -131,6 +131,11 @@ func (c *Client) Scan(
 	return nil
 }
 
+// Metadata returns all metadata fields
+func (c *Client) Metadata(ctx context.Context) (map[string]string, error) {
+	return c.impl.Metadata(ctx)
+}
+
 // Read reads an event at the given offset version
 func (c *Client) Read(
 	ctx context.Context,
@@ -221,6 +226,8 @@ type Log interface {
 
 // Implementer represents a client implementer
 type Implementer interface {
+	Metadata(ctx context.Context) (map[string]string, error)
+
 	Append(
 		ctx context.Context,
 		assumeVersion bool,

--- a/client/inmem.go
+++ b/client/inmem.go
@@ -19,6 +19,25 @@ func NewInmem(e *eventlog.EventLog) *Inmem {
 	return &Inmem{e}
 }
 
+func (c *Inmem) Metadata(ctx context.Context) (
+	m map[string]string,
+	err error,
+) {
+	l := c.e.MetadataLen()
+	if l < 1 {
+		return nil, nil
+	}
+	m = make(map[string]string, l)
+	c.e.ScanMetadata(func(f, v string) bool {
+		if err = ctx.Err(); err != nil {
+			return false
+		}
+		m[f] = v
+		return true
+	})
+	return m, nil
+}
+
 func (c *Inmem) Append(
 	ctx context.Context,
 	assumeVersion bool,

--- a/cmd/eventlog/cli/array_flag.go
+++ b/cmd/eventlog/cli/array_flag.go
@@ -1,0 +1,14 @@
+package cli
+
+import "fmt"
+
+type arrayFlag []string
+
+func (f *arrayFlag) String() string {
+	return fmt.Sprintf("%v", *f)
+}
+
+func (f *arrayFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}

--- a/cmd/eventlog/cli/cli.go
+++ b/cmd/eventlog/cli/cli.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	CmdInmem  = "inmem"
+	CmdCreate = "create"
+	CmdOpen   = "open"
+	CmdCheck  = "check"
+	CmdHelp   = "help"
+
+	ParamVerbose         = "verbose"
+	ParmMeta             = "m"
+	ParamHTTPHost        = "http-host"
+	ParamHTTPReadTimeout = "http-read-timeout"
+)
+
+func Parse(args []string) (mode interface{}, err error) {
+	if a := args; len(a) < 1 {
+		return nil, fmt.Errorf("missing command")
+	}
+
+	switch a := args[0]; a {
+	case CmdInmem:
+		mode, err = parseModeInmem(args[1:])
+	case CmdCreate:
+		mode, err = parseModeCreate(args[1:])
+	case CmdOpen:
+		mode, err = parseModeOpen(args[1:])
+	case CmdCheck:
+		mode, err = parseModeCheck(args[1:])
+	case CmdHelp:
+		mode, err = parseModeHelp(args[1:])
+	default:
+		err = fmt.Errorf(
+			"invalid command %q, use help to show all available commands",
+			a,
+		)
+	}
+	return
+}
+
+func newFlagSet() *flag.FlagSet {
+	s := flag.NewFlagSet("", flag.ExitOnError)
+	return s
+}
+
+func httpArgs(flags *flag.FlagSet) (
+	flagHTTPHost *string,
+	flagHTTPReadTimeout *time.Duration,
+) {
+	flagHTTPHost = flags.String(
+		ParamHTTPHost,
+		DefaultHTTPHost,
+		"TCP address to listen to",
+	)
+	flagHTTPReadTimeout = flags.Duration(
+		ParamHTTPReadTimeout,
+		DefaultHTTPReadTimeout,
+		"read timeout of the HTTP API server",
+	)
+	return
+}
+
+type HTTP struct {
+	Host        string
+	ReadTimeout time.Duration
+}
+
+const (
+	DefaultHTTPHost        = ":8080"
+	DefaultHTTPReadTimeout = 2 * time.Second
+	DefaultCheckVerbose    = true
+)
+
+func parseMetaFields(fields []string) (map[string]string, error) {
+	f := make(map[string]string)
+	for _, a := range fields {
+		{
+			k, v, err := parseMetaField(a)
+			if err == nil {
+				f[k] = v
+				continue
+			}
+		}
+		return nil, fmt.Errorf("invalid argument: %q", a)
+	}
+	return f, nil
+}
+
+func parseMetaField(s string) (key, value string, err error) {
+	p := strings.Split(s, ":")
+	if len(p) != 2 {
+		err = fmt.Errorf("invalid key value pair %q", p[1])
+		return
+	}
+	key, value = p[0], p[1]
+	return
+}

--- a/cmd/eventlog/cli/cli_test.go
+++ b/cmd/eventlog/cli/cli_test.go
@@ -1,0 +1,145 @@
+package cli_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/romshark/eventlog/cmd/eventlog/cli"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	for _, tt := range []struct {
+		in  []string
+		err func(*testing.T, error)
+		out interface{}
+	}{
+		{
+			in: []string{"help", "testcmd"},
+			out: cli.ModeHelp{
+				Command: "testcmd",
+			},
+		},
+		{
+			in: []string{"open", "/path/to/file"},
+			out: cli.ModeOpen{
+				Path: "/path/to/file",
+				HTTP: cli.HTTP{
+					Host:        cli.DefaultHTTPHost,
+					ReadTimeout: cli.DefaultHTTPReadTimeout,
+				},
+			},
+		},
+		{
+			in: []string{
+				"open", "/path/to/file",
+				"-http-host", "testhost:9090",
+				"-http-read-timeout", "5ms",
+			},
+			out: cli.ModeOpen{
+				Path: "/path/to/file",
+				HTTP: cli.HTTP{
+					Host:        "testhost:9090",
+					ReadTimeout: 5 * time.Millisecond,
+				},
+			},
+		},
+		{
+			in: []string{"inmem"},
+			out: cli.ModeInmem{
+				HTTP: cli.HTTP{
+					Host:        cli.DefaultHTTPHost,
+					ReadTimeout: cli.DefaultHTTPReadTimeout,
+				},
+				MetaFields: map[string]string{},
+			},
+		},
+		{
+			in: []string{
+				"inmem",
+				"-http-host", "testhost:9090",
+				"-http-read-timeout", "5ms",
+				"-meta", "foo:bar",
+				"-meta", "bazz:fazz",
+			},
+			out: cli.ModeInmem{
+				HTTP: cli.HTTP{
+					Host:        "testhost:9090",
+					ReadTimeout: 5 * time.Millisecond,
+				},
+				MetaFields: map[string]string{
+					"foo":  "bar",
+					"bazz": "fazz",
+				},
+			},
+		},
+		{
+			in: []string{"check", "path/to/file"},
+			out: cli.ModeCheck{
+				Path:    "path/to/file",
+				Verbose: true,
+			},
+		},
+		{
+			in: []string{
+				"check", "path/to/file",
+				"-verbose=false",
+			},
+			out: cli.ModeCheck{
+				Path:    "path/to/file",
+				Verbose: false,
+			},
+		},
+		{
+			in: []string{"create", "/path/to/file"},
+			out: cli.ModeCreate{
+				Path:       "/path/to/file",
+				MetaFields: map[string]string{},
+			},
+		},
+		{
+			in: []string{
+				"create", "/path/to/file",
+				"-meta", "foo:bar",
+				"-meta", "bazz:fazz",
+			},
+			out: cli.ModeCreate{
+				Path: "/path/to/file",
+				MetaFields: map[string]string{
+					"foo":  "bar",
+					"bazz": "fazz",
+				},
+			},
+		},
+		{
+			in: []string{"open"},
+			err: func(t *testing.T, err error) {
+				require.Equal(t, "missing path", err.Error())
+			},
+		},
+		{
+			in: []string{"check"},
+			err: func(t *testing.T, err error) {
+				require.Equal(t, "missing path", err.Error())
+			},
+		},
+		{
+			in: []string{"create"},
+			err: func(t *testing.T, err error) {
+				require.Equal(t, "missing path", err.Error())
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			mode, err := cli.Parse(tt.in)
+			if tt.err != nil {
+				require.Error(t, err)
+				tt.err(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.out, mode)
+			}
+		})
+	}
+}

--- a/cmd/eventlog/cli/mode_check.go
+++ b/cmd/eventlog/cli/mode_check.go
@@ -1,0 +1,23 @@
+package cli
+
+import "errors"
+
+type ModeCheck struct {
+	Path    string
+	Verbose bool
+}
+
+func parseModeCheck(args []string) (m ModeCheck, err error) {
+	if len(args) < 1 {
+		return m, errors.New("missing path")
+	}
+	m.Path = args[0]
+
+	flags := newFlagSet()
+	verbose := flags.Bool(ParamVerbose, DefaultCheckVerbose, "Print progress")
+	flags.Parse(args[1:])
+
+	m.Verbose = *verbose
+
+	return m, nil
+}

--- a/cmd/eventlog/cli/mode_create.go
+++ b/cmd/eventlog/cli/mode_create.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"errors"
+)
+
+type ModeCreate struct {
+	Path       string
+	MetaFields map[string]string
+}
+
+func parseModeCreate(args []string) (m ModeCreate, err error) {
+	if len(args) < 1 {
+		return m, errors.New("missing path")
+	}
+	m.Path = args[0]
+
+	var metaFields arrayFlag
+
+	flags := newFlagSet()
+	flags.Var(&metaFields, "meta", "Metadata fields")
+	flags.Parse(args[1:])
+
+	m.MetaFields, err = parseMetaFields(metaFields)
+	if err != nil {
+		return m, err
+	}
+	return m, nil
+}

--- a/cmd/eventlog/cli/mode_help.go
+++ b/cmd/eventlog/cli/mode_help.go
@@ -1,0 +1,15 @@
+package cli
+
+import "errors"
+
+type ModeHelp struct {
+	Command string
+}
+
+func parseModeHelp(args []string) (m ModeHelp, err error) {
+	if len(args) < 1 {
+		return m, errors.New("missing command name")
+	}
+	m.Command = args[0]
+	return m, nil
+}

--- a/cmd/eventlog/cli/mode_inmem.go
+++ b/cmd/eventlog/cli/mode_inmem.go
@@ -1,0 +1,25 @@
+package cli
+
+type ModeInmem struct {
+	HTTP
+	MetaFields map[string]string
+}
+
+func parseModeInmem(args []string) (m ModeInmem, err error) {
+	var metaFields arrayFlag
+
+	flags := newFlagSet()
+	flags.Var(&metaFields, "meta", "Metadata fields")
+	flagHTTPHost, flagHTTPReadTimeout := httpArgs(flags)
+	flags.Parse(args)
+
+	m.HTTP.Host = *flagHTTPHost
+	m.HTTP.ReadTimeout = *flagHTTPReadTimeout
+
+	m.MetaFields, err = parseMetaFields(metaFields)
+	if err != nil {
+		return m, err
+	}
+
+	return m, nil
+}

--- a/cmd/eventlog/cli/mode_open.go
+++ b/cmd/eventlog/cli/mode_open.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"errors"
+)
+
+type ModeOpen struct {
+	HTTP
+	Path string
+}
+
+func parseModeOpen(args []string) (m ModeOpen, err error) {
+	if len(args) < 1 {
+		return m, errors.New("missing path")
+	}
+	m.Path = args[0]
+
+	flags := newFlagSet()
+	flagHTTPHost, flagHTTPReadTimeout := httpArgs(flags)
+	flags.Parse(args[1:])
+
+	m.HTTP.Host = *flagHTTPHost
+	m.HTTP.ReadTimeout = *flagHTTPReadTimeout
+
+	return m, nil
+}

--- a/cmd/eventlog/cli/print_help.go
+++ b/cmd/eventlog/cli/print_help.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+)
+
+type section struct {
+	Title   string
+	Content interface{}
+}
+
+type list []interface{}
+
+func print(
+	w io.Writer,
+	indentStr string,
+	indent int,
+	x interface{},
+) {
+	printIdent := func(l int) {
+		for i := 0; i < l; i++ {
+			fmt.Fprint(w, indentStr)
+		}
+	}
+
+	switch x := x.(type) {
+	case string:
+		printIdent(indent)
+		fmt.Fprintln(w, x)
+	case list:
+		for _, v := range x {
+			print(w, indentStr, indent, v)
+		}
+	case section:
+		printIdent(indent)
+		fmt.Fprintln(w, x.Title)
+		print(w, indentStr, indent+1, x.Content)
+	default:
+		panic(fmt.Errorf("unsupported print item type: %T", x))
+	}
+}
+
+var helpOptMeta = section{
+	Title: fmt.Sprintf("-%s '<key>:<value>'", ParmMeta),
+	Content: "Appends a new metadata key-value pair separated by a colon " +
+		"to the immutable header of the log file. " +
+		"Can be used multiple times.",
+}
+var helpOptHTTPHost = section{
+	Title: fmt.Sprintf("-%s <host>[:port]", ParamHTTPHost),
+	Content: list{
+		"Defines the HTTP API host address.",
+		fmt.Sprintf("Default: '%s'", DefaultHTTPHost),
+	},
+}
+var helpOptHTTPReadTimeout = section{
+	Title: fmt.Sprintf("-%s <time>", ParamHTTPReadTimeout),
+	Content: list{
+		"Defines the read-timeout duration for the HTTP API.",
+		fmt.Sprintf("Default: '%s'", DefaultHTTPReadTimeout),
+	},
+}
+var helpOptVerbose = section{
+	Title: fmt.Sprintf("-%s", ParamVerbose),
+	Content: list{
+		"Enables verbose mode.",
+		fmt.Sprintf("Default: %t", DefaultCheckVerbose),
+	},
+}
+var helpCmdCreate = list{
+	fmt.Sprintf("usage: eventlog %s <path> <parameters>", CmdCreate),
+	"",
+	"Creates a new file-based event log at the given path.",
+	"",
+	section{
+		Title:   "parameters:",
+		Content: helpOptMeta,
+	},
+}
+var helpCmdOpen = list{
+	fmt.Sprintf("usage: eventlog %s <path> <parameters>", CmdOpen),
+	"",
+	"Loads an event log from a file " +
+		"and starts listening on the HTTP API.",
+	"",
+	section{
+		Title: "parameters:",
+		Content: list{
+			helpOptHTTPHost,
+			helpOptHTTPReadTimeout,
+		},
+	},
+}
+var helpCmdCheck = list{
+	fmt.Sprintf("usage: eventlog %s <path> <parameters>", CmdCheck),
+	"",
+	"Performs an integrity check on the given event log file.",
+	"",
+	section{"parameters:", list{
+		helpOptVerbose,
+	}},
+}
+var helpCmdInmem = list{
+	fmt.Sprintf("usage: eventlog %s <parameters>", CmdInmem),
+	"",
+	"Starts a volatile in-memory event log " +
+		"listening on the HTTP API.",
+	"",
+	section{
+		Title: "parameters:",
+		Content: list{
+			helpOptMeta,
+			helpOptHTTPHost,
+			helpOptHTTPReadTimeout,
+		},
+	},
+}
+var helpDefaultHelp = list{
+	fmt.Sprintf("usage: eventlog <command> [<parameters>]"),
+	section{
+		Title: "available commands:",
+		Content: list{
+			CmdCreate,
+			CmdOpen,
+			CmdCheck,
+			CmdInmem,
+		},
+	},
+}
+
+func PrintHelp(w io.Writer, command string) {
+	print(w, "  ", 0, func() interface{} {
+		switch command {
+		case CmdCreate:
+			return helpCmdCreate
+		case CmdOpen:
+			return helpCmdOpen
+		case CmdCheck:
+			return helpCmdCheck
+		case CmdInmem:
+			return helpCmdInmem
+		}
+		return helpDefaultHelp
+	}())
+}

--- a/cmd/eventlog/handle_check.go
+++ b/cmd/eventlog/handle_check.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/romshark/eventlog/cmd/eventlog/cli"
+	"github.com/romshark/eventlog/eventlog/file"
+	enginefile "github.com/romshark/eventlog/eventlog/file"
+)
+
+func handleCheck(
+	logInfo *log.Logger,
+	logErr *log.Logger,
+	m cli.ModeCheck,
+) {
+	var fileSize int64
+	if info, err := os.Stat(m.Path); os.IsNotExist(err) {
+		// File doesn't exist, skip check
+		logErr.Fatal("file not found")
+	} else if err != nil {
+		logErr.Fatalf("reading source file info: %s", err)
+	} else {
+		fileSize = info.Size()
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		select {
+		case <-stop:
+			// Cancel integrity check
+			cancel()
+			logInfo.Println("canceling integrity check")
+		case <-ctx.Done():
+		}
+	}()
+
+	fl, err := os.OpenFile(m.Path, os.O_RDONLY, 0644)
+	if err != nil {
+		logErr.Fatalf("opening file for integrity check: %s", err)
+	}
+	defer fl.Close()
+
+	onEvent := func(
+		offset int64,
+		checksum uint64,
+		timestamp uint64,
+		label []byte,
+		payload []byte,
+	) error {
+		// Integrity check progress
+		logInfo.Printf(
+			"%.2f: Valid entry at offset %d\n"+
+				" time:            %s\n"+
+				" label:           %q\n"+
+				" payload (bytes): %d\n"+
+				" checksum:        %d\n",
+			float64(offset)/float64(fileSize)*100,
+			offset,
+			time.Unix(int64(timestamp), 0),
+			string(label),
+			len(payload),
+			checksum,
+		)
+		return nil
+	}
+
+	if !m.Verbose {
+		onEvent = func(
+			offset int64,
+			checksum uint64,
+			timestamp uint64,
+			label []byte,
+			payload []byte,
+		) error {
+			return nil
+		}
+	}
+
+	if err := enginefile.CheckIntegrity(
+		ctx,
+		make([]byte, file.MinReadBufferLen),
+		fl,
+		onEvent,
+	); err != nil {
+		logErr.Fatalf("checking file integrity: %s", err)
+	}
+}

--- a/cmd/eventlog/handle_open.go
+++ b/cmd/eventlog/handle_open.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"log"
+
+	"github.com/romshark/eventlog/cmd/eventlog/cli"
+	"github.com/romshark/eventlog/eventlog"
+	filelog "github.com/romshark/eventlog/eventlog/file"
+)
+
+func handleOpen(
+	logInfo *log.Logger,
+	logErr *log.Logger,
+	m cli.ModeOpen,
+) {
+	f, err := filelog.Open(m.Path[len("file:"):])
+	if err != nil {
+		logErr.Fatal(err)
+	}
+
+	eventLog := eventlog.New(f)
+	launchFrontendFastHTTP(logInfo, logErr, eventLog, m.HTTP)
+}

--- a/cmd/eventlog/launch_frontend_fasthttp.go
+++ b/cmd/eventlog/launch_frontend_fasthttp.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+
+	"github.com/romshark/eventlog/cmd/eventlog/cli"
+	"github.com/romshark/eventlog/eventlog"
+	ffhttp "github.com/romshark/eventlog/frontend/fasthttp"
+
+	"github.com/valyala/fasthttp"
+)
+
+func launchFrontendFastHTTP(
+	logInfo *log.Logger,
+	logErr *log.Logger,
+	eventlog *eventlog.EventLog,
+	http cli.HTTP,
+) {
+	// Initialize the frontend
+	server := ffhttp.New(logErr, eventlog)
+	httpServer := &fasthttp.Server{
+		Handler:     server.Serve,
+		ReadTimeout: http.ReadTimeout,
+	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+
+	// Launch server
+	go func() {
+		logInfo.Printf("listening on %s", http.Host)
+		if err := httpServer.ListenAndServe(http.Host); err != nil {
+			logErr.Fatal(err)
+		}
+	}()
+
+	// Await stop
+	<-stop
+
+	logInfo.Println("shutting down...")
+	if err := httpServer.Shutdown(); err != nil {
+		logErr.Printf("shutting down http server: %s", err)
+	}
+
+	server.Close()
+
+	logInfo.Println("closing eventlog...")
+	if err := eventlog.Close(); err != nil {
+		logErr.Fatalf("closing eventlog: %s", err)
+	}
+
+	logInfo.Println("shutdown")
+}

--- a/cmd/eventlog/main.go
+++ b/cmd/eventlog/main.go
@@ -1,179 +1,48 @@
 package main
 
 import (
-	"context"
-	"flag"
+	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"time"
 
+	"github.com/romshark/eventlog/cmd/eventlog/cli"
 	"github.com/romshark/eventlog/eventlog"
-	"github.com/romshark/eventlog/eventlog/file"
-	enginefile "github.com/romshark/eventlog/eventlog/file"
-	engineinmem "github.com/romshark/eventlog/eventlog/inmem"
-	ffhttp "github.com/romshark/eventlog/frontend/fasthttp"
-
-	"github.com/valyala/fasthttp"
-)
-
-const (
-	engineInmem = "inmem"
-	engineFile  = "file"
-)
-
-var (
-	flagAPIHTTP = flag.String(
-		"apihttp",
-		":8080",
-		"TCP address to listen to",
-	)
-	flagAPIHTTPReadTimeout = flag.Duration(
-		"apihttp-read-timeout",
-		2*time.Second,
-		"read timeout of the HTTP API server",
-	)
-	flagStoreEngine = flag.String(
-		"store",
-		engineFile,
-		"storage engine",
-	)
-	flagStoreFilePath = flag.String(
-		"storage",
-		"./eventlog.db",
-		"event storage file path",
-	)
-	flagCheckIntegrity = flag.Bool(
-		"check-integrity",
-		false,
-		"perform file integrity check on launch",
-	)
+	filelog "github.com/romshark/eventlog/eventlog/file"
+	"github.com/romshark/eventlog/eventlog/inmem"
 )
 
 func main() {
-	flag.Parse()
-
 	logInfo := log.New(os.Stdout, "", log.LstdFlags)
 	logErr := log.New(os.Stderr, "ERR", log.LstdFlags)
 
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, os.Interrupt)
+	mode, err := cli.Parse(os.Args[1:])
+	if err != nil {
+		cli.PrintHelp(os.Stdout, "")
+		os.Exit(1)
+	}
 
-	// Initialize the event log engine
-	var eventLogImpl eventlog.Implementer
-	var err error
-	switch *flagStoreEngine {
-	case engineInmem:
-		eventLogImpl = engineinmem.New()
-	case engineFile:
-		func() {
-			if !*flagCheckIntegrity {
-				// Skip file integrity check
-				return
-			}
+	switch m := mode.(type) {
+	case cli.ModeCheck:
+		handleCheck(logInfo, logErr, m)
 
-			var fileSize int64
-			if info, err := os.Stat(*flagStoreFilePath); os.IsNotExist(err) {
-				// File doesn't exist, skip check
-				return
-			} else if err != nil {
-				logErr.Fatalf("reading source file info: %s", err)
-			} else {
-				fileSize = info.Size()
-			}
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			go func() {
-				select {
-				case <-stop:
-					// Cancel integrity check
-					cancel()
-					logInfo.Println("canceling integrity check")
-				case <-ctx.Done():
-				}
-			}()
-
-			fl, err := os.OpenFile(*flagStoreFilePath, os.O_RDONLY, 0644)
-			if err != nil {
-				logErr.Fatalf("opening file for integrity check: %s", err)
-			}
-			defer fl.Close()
-
-			if err := enginefile.CheckIntegrity(
-				ctx,
-				make([]byte, file.MinReadBufferLen),
-				fl,
-				func(
-					offset int64,
-					checksum uint64,
-					timestamp uint64,
-					label []byte,
-					payload []byte,
-				) error {
-					// Integrity check progress
-					logInfo.Printf(
-						"%.2f: Valid entry at offset %d\n"+
-							" time:            %s\n"+
-							" label:           %q\n"+
-							" payload (bytes): %d\n"+
-							" checksum:        %d\n",
-						float64(offset)/float64(fileSize)*100,
-						offset,
-						time.Unix(int64(timestamp), 0),
-						string(label),
-						len(payload),
-						checksum,
-					)
-					return nil
-				},
-			); err != nil {
-				logErr.Fatalf("checking file integrity: %s", err)
-			}
-		}()
-
-		eventLogImpl, err = enginefile.New(*flagStoreFilePath)
-		if err != nil {
+	case cli.ModeCreate:
+		if err := filelog.Create(
+			m.Path, m.MetaFields, 0777,
+		); err != nil {
 			logErr.Fatal(err)
 		}
-		defer eventLogImpl.(*enginefile.File).Close()
+
+	case cli.ModeOpen:
+		handleOpen(logInfo, logErr, m)
+
+	case cli.ModeInmem:
+		eventLog := eventlog.New(inmem.New(m.MetaFields))
+		launchFrontendFastHTTP(logInfo, logErr, eventLog, m.HTTP)
+
+	case cli.ModeHelp:
+		cli.PrintHelp(os.Stdout, m.Command)
 
 	default:
-		logErr.Fatalf("unsupported engine %q", *flagStoreEngine)
+		panic(fmt.Errorf("unknown mode: %T", mode))
 	}
-
-	eventLog := eventlog.New(eventLogImpl)
-
-	// Initialize the frontend
-	server := ffhttp.New(logErr, eventLog)
-	httpServer := &fasthttp.Server{
-		Handler:     server.Serve,
-		ReadTimeout: *flagAPIHTTPReadTimeout,
-	}
-
-	// Launch server
-	go func() {
-		logInfo.Printf("listening on %s", *flagAPIHTTP)
-		if err := httpServer.ListenAndServe(*flagAPIHTTP); err != nil {
-			logErr.Fatal(err)
-		}
-	}()
-
-	// Await stop
-	<-stop
-
-	logInfo.Println("shutting down...")
-	if err := httpServer.Shutdown(); err != nil {
-		logErr.Printf("shutting down http server: %s", err)
-	}
-
-	server.Close()
-
-	logInfo.Println("closing eventlog...")
-	if err := eventLog.Close(); err != nil {
-		logErr.Fatalf("closing eventlog: %s", err)
-	}
-
-	logInfo.Println("shutdown")
 }

--- a/eventlog/eventlog.go
+++ b/eventlog/eventlog.go
@@ -36,6 +36,13 @@ func (e Event) Validate() error {
 
 // Implementer represents an event log engine's implementer
 type Implementer interface {
+	// MetadataLen returns the number of metadata fields
+	MetadataLen() int
+
+	// ScanMetadata iterates over all metadata fields calling fn for each.
+	// The scan is interrupted if fn returns false
+	ScanMetadata(fn func(field, value string) bool)
+
 	// Version returns the current version of the log
 	Version() uint64
 
@@ -139,6 +146,17 @@ func (e *EventLog) Version() uint64 {
 // FirstOffset returns the offset of the first entry in the log
 func (e *EventLog) FirstOffset() uint64 {
 	return e.impl.FirstOffset()
+}
+
+// MetadataLen returns the number of metadata fields
+func (e *EventLog) MetadataLen() int {
+	return e.impl.MetadataLen()
+}
+
+// ScanMetadata iterates over all metadata fields calling fn for each.
+// The scan is interrupted if fn returns false
+func (e *EventLog) ScanMetadata(fn func(field, value string) bool) {
+	e.impl.ScanMetadata(fn)
 }
 
 // Append appends an event with the given payload to the log

--- a/eventlog/file/internal/checksum.go
+++ b/eventlog/file/internal/checksum.go
@@ -10,8 +10,6 @@ import (
 )
 
 // Checksum computes the 64-bit checksum hash for the given event.
-//
-// WARNING: the buffer must be at least 8 bytes long.
 func Checksum(
 	buffer []byte,
 	hasher Hasher,
@@ -19,6 +17,12 @@ func Checksum(
 	label []byte,
 	payload []byte,
 ) (checksum uint64, err error) {
+	if len(buffer) < 8 {
+		buffer = make([]byte, 8)
+	}
+
+	hasher.Reset()
+
 	write := func(data []byte) (failed bool) {
 		var n int
 		if n, err = hasher.Write(data); err != nil {

--- a/eventlog/file/internal/read_event.go
+++ b/eventlog/file/internal/read_event.go
@@ -14,9 +14,11 @@ type ReaderConf struct {
 	MaxPayloadLen uint32
 }
 
-// ReadEvent returns io.EOF when there's nothing more to read
+// ReadEvent reads an event entry from the given reader at the given offset.
+// Checks the read entry's integrity by validating the read checksum.
+// Returns io.EOF when there's nothing more to read.
 //
-// WARNING: lb and pl both reference the given buffer.
+// WARNING: returned label and payload slices both reference the given buffer.
 // WARNING: buffer must be at least the size of the sum of the
 // maximum possible payload and label lengths.
 func ReadEvent(
@@ -34,6 +36,7 @@ func ReadEvent(
 	err error,
 ) {
 	buffer.MustValidate(conf)
+	hasher.Reset()
 
 	buf8 := buffer[:8]
 	buf4 := buffer[:4]

--- a/eventlog/file/internal/read_header.go
+++ b/eventlog/file/internal/read_header.go
@@ -2,29 +2,60 @@ package internal
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 )
 
-// ReadHeader reads a file header
-//
-// WARNING: buffer must be at least 4 bytes long.
+// ReadHeader reads the header of a log file
 func ReadHeader(
-	buffer []byte,
+	buffer ReadBuffer,
 	reader OffsetReader,
-	checkVersion func(uint32) error,
-) error {
+	hasher Hasher,
+	conf ReaderConf,
+	onMeta func(field, value string) error,
+) (headerLen int64, err error) {
+	buffer.MustValidate(conf)
+
 	buf4 := buffer[:4]
-	n, err := reader.ReadAt(buf4, 0)
+
+	// Read version
+	if _, err := reader.ReadAt(buf4, 0); err != nil {
+		return 0, fmt.Errorf("reading version: %w", err)
+	}
+	if v := binary.LittleEndian.Uint32(buf4); v != 4 {
+		return headerLen, fmt.Errorf("unsupported file version (%d)", v)
+	}
+	headerLen += 4
+
+	_, _, _, payload, ln, err := ReadEvent(
+		buffer, reader, hasher, 4, conf,
+	)
 	if err != nil {
-		return err
+		return 0, fmt.Errorf("reading metadata: %w", err)
 	}
-	if n != 4 {
-		return fmt.Errorf(
-			"reading version header (expected: 4, actual: %d)", n,
-		)
+	headerLen += ln
+
+	if onMeta != nil {
+		var metadata map[string]string
+		if err := json.Unmarshal(payload, &metadata); err != nil {
+			return 0, fmt.Errorf("decoding metadata JSON: %w", err)
+		}
+		for f, v := range metadata {
+			if err := onMeta(f, v); err != nil {
+				return 0, err
+			}
+		}
 	}
-	return checkVersion(binary.LittleEndian.Uint32(buf4))
+
+	return headerLen, nil
 }
+
+// // Read version
+// if buf := readNext(4); buf == nil {
+// 	return nil, headerLen, fmt.Errorf("reading version: %w", err)
+// } else if v := binary.LittleEndian.Uint32(buf); v != 4 {
+// 	return nil, headerLen, fmt.Errorf("unsupported file version (%d)", v)
+// }
 
 type OffsetReader interface {
 	ReadAt(buf []byte, offset int64) (read int, err error)

--- a/eventlog/file/internal/read_header_test.go
+++ b/eventlog/file/internal/read_header_test.go
@@ -1,22 +1,56 @@
 package internal_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/romshark/eventlog/eventlog/file/internal"
+	"github.com/romshark/eventlog/eventlog/file/internal/test"
+
+	"github.com/cespare/xxhash"
 	"github.com/stretchr/testify/require"
 )
 
 func TestReadHeader(t *testing.T) {
-	const expectedVersion = uint32(123)
-	rec := NewReadRecorder(t,
-		ExpectedRead{Offset: 0, Write: internal.MakeU32LE(expectedVersion)},
-	)
-	checkVersion := func(v uint32) error {
-		require.Equal(t, expectedVersion, v)
-		return nil
+	meta := map[string]string{
+		"field1": "value1",
+		"field2": "value2",
 	}
-	require.NoError(t, internal.ReadHeader(
-		make([]byte, 4), rec, checkVersion,
-	))
+
+	metaJSON, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	mev := test.TestEvent{Payload: string(metaJSON)}
+
+	rec := NewReadRecorder(t,
+		ExpectedRead{Offset: 0, Write: internal.MakeU32LE(4)},
+		ExpectedRead{Offset: 4, Write: internal.MakeU64LE(mev.Checksum(t))},
+		ExpectedRead{Offset: 12, Write: internal.MakeU64LE(mev.Timestamp)},
+		ExpectedRead{Offset: 20, Write: internal.MakeU16LE(mev.LabelLen())},
+		ExpectedRead{Offset: 22, Write: internal.MakeU32LE(mev.PayloadLen())},
+		ExpectedRead{Offset: 26, Write: metaJSON},
+	)
+
+	metadata := make(map[string]string)
+	headerLen, err := internal.ReadHeader(
+		test.NewBuffer(),
+		rec,
+		xxhash.New(),
+		internal.ReaderConf{
+			MinPayloadLen: 7,
+			MaxPayloadLen: 512,
+		},
+		func(f, v string) error {
+			metadata[f] = v
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(26+len(metaJSON)), headerLen)
+
+	require.Len(t, metadata, 2)
+	for f, v := range meta {
+		require.Contains(t, metadata, f)
+		require.Equal(t, v, metadata[f])
+	}
 }

--- a/eventlog/file/internal/test/test.go
+++ b/eventlog/file/internal/test/test.go
@@ -1,0 +1,112 @@
+package test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/romshark/eventlog/eventlog/file"
+	"github.com/romshark/eventlog/eventlog/file/internal"
+	bin "github.com/romshark/eventlog/internal/bin"
+
+	"github.com/cespare/xxhash"
+	"github.com/stretchr/testify/require"
+)
+
+func NewBuffer() internal.ReadBuffer {
+	return make([]byte, file.MinReadBufferLen)
+}
+
+type FakeSrc []byte
+
+func (f FakeSrc) ReadAt(buf []byte, offset int64) (read int, err error) {
+	if offset >= int64(len(f)) {
+		return 0, io.EOF
+	}
+	d := f[offset:]
+	if len(buf) > len(d) {
+		buf = buf[:len(d)]
+	}
+	copy(buf, d)
+	return len(buf), nil
+}
+
+func Compose(
+	t *testing.T,
+	parts ...interface{},
+) (f FakeSrc, headerLength int64) {
+	c := bin.Compose(parts...)
+	hlen, err := internal.ReadHeader(
+		NewBuffer(),
+		FakeSrc(c),
+		xxhash.New(),
+		internal.ReaderConf{
+			MinPayloadLen: 7,
+			MaxPayloadLen: 512,
+		},
+		nil,
+	)
+	require.NotZero(t, hlen)
+	require.NoError(t, err)
+	return FakeSrc(c), hlen
+}
+
+func ComposeWithValidHeader(
+	t *testing.T,
+	parts ...interface{},
+) (f FakeSrc, headerLength int64) {
+	m := TestEvent{
+		Timestamp: 0,
+		Label:     "",
+		Payload:   `{"m":"d"}`,
+	}
+	header := []interface{}{
+		// header
+		uint32(file.SupportedProtoVersion),
+		// metadata
+		m.Checksum(t),  // checksum
+		m.Timestamp,    // timestamp
+		m.LabelLen(),   // label length
+		m.PayloadLen(), // payload length
+		m.Payload,      // payload
+	}
+	return bin.Compose(append(header, parts...)...), 35
+}
+
+func ValidEvent1() TestEvent {
+	return TestEvent{
+		Timestamp: 8888888888,
+		Label:     "",
+		Payload:   `{"x":0}`,
+	}
+}
+
+func ValidEvent2() TestEvent {
+	return TestEvent{
+		Timestamp: 9999999999,
+		Label:     "foo_bar",
+		Payload:   `{"medium":"size"}`,
+	}
+}
+
+type TestEvent struct {
+	Timestamp uint64
+	Label     string
+	Payload   string
+}
+
+func (e TestEvent) LabelLen() uint16 {
+	return uint16(len(e.Label))
+}
+
+func (e TestEvent) PayloadLen() uint32 {
+	return uint32(len(e.Payload))
+}
+
+func (e TestEvent) Len() int64 {
+	return int64(22 + len(e.Label) + len(e.Payload))
+}
+
+func (e TestEvent) Checksum(t *testing.T) uint64 {
+	c := internal.ChecksumT(t, e.Timestamp, e.Label, e.Payload)
+	return c
+}

--- a/eventlog/file/internal/test/test_test.go
+++ b/eventlog/file/internal/test/test_test.go
@@ -1,0 +1,46 @@
+package test_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/romshark/eventlog/eventlog/file/internal/test"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeSrc(t *testing.T) {
+	r := require.New(t)
+	f := test.FakeSrc("0123456789")
+
+	b := make([]byte, 4)
+	n, err := f.ReadAt(b, 0)
+	r.NoError(err)
+	r.Equal(4, n)
+	r.Equal("0123", string(b))
+
+	b = make([]byte, 20)
+	n, err = f.ReadAt(b, 0)
+	r.NoError(err)
+	r.Equal(10, n)
+	r.Equal("0123456789", string(b[:n]))
+
+	b = make([]byte, 20)
+	n, err = f.ReadAt(b, 5)
+	r.NoError(err)
+	r.Equal(5, n)
+	r.Equal("56789", string(b[:n]))
+
+	b = make([]byte, 2)
+	n, err = f.ReadAt(b, 6)
+	r.NoError(err)
+	r.Equal(2, n)
+	r.Equal("67", string(b[:n]))
+
+	b = make([]byte, 2)
+	n, err = f.ReadAt(b, 10)
+	r.Error(err)
+	r.Error(io.EOF, err)
+	r.Zero(n)
+	r.Equal([]byte{0, 0}, b)
+}

--- a/eventlog/file/internal/write_event.go
+++ b/eventlog/file/internal/write_event.go
@@ -11,22 +11,26 @@ import (
 
 type Hasher interface {
 	io.Writer
+	Reset()
 	Sum64() uint64
 }
 
-type Writer interface {
+type SyncWriter interface {
 	WriteAt(data []byte, offset int64) (int, error)
 	Sync() error
 }
 
 func WriteEvent(
-	writer Writer,
+	writer SyncWriter,
 	buffer []byte,
 	checksum uint64,
 	offset int64,
 	timestamp uint64,
 	event eventlog.Event,
 ) (written int, err error) {
+	if len(buffer) < 8 {
+		buffer = make([]byte, 8)
+	}
 	buf8 := buffer[:8]
 	buf4 := buffer[:4]
 	buf2 := buffer[:2]

--- a/eventlog/file/internal/write_file_header.go
+++ b/eventlog/file/internal/write_file_header.go
@@ -2,20 +2,63 @@ package internal
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
-	"io"
+
+	"github.com/romshark/eventlog/eventlog"
 )
 
+const MaxMetaDataLen = 4294967295
+
+// WriteFileHeader writes the file header
 func WriteFileHeader(
-	buffer []byte,
-	writer io.Writer,
-	supportedProtoVersion uint32,
-) error {
-	// New file, write header
-	bufUint32 := buffer[:4]
-	binary.LittleEndian.PutUint32(bufUint32, supportedProtoVersion)
-	if _, err := writer.Write(bufUint32); err != nil {
-		return fmt.Errorf("writing header version: %w", err)
+	writer SyncWriter,
+	hasher Hasher,
+	metadata map[string]string,
+) (written int, err error) {
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return written, fmt.Errorf("encoding metadata JSON: %w", err)
 	}
-	return nil
+
+	if l := len(metadataJSON); l > MaxMetaDataLen {
+		return written, fmt.Errorf(
+			"max meta info JSON length (%d) exceeded (%d)",
+			MaxMetaDataLen, l,
+		)
+	}
+
+	var metaChecksum uint64
+	if metaChecksum, err = Checksum(
+		nil,
+		hasher,
+		0,
+		nil,
+		metadataJSON,
+	); err != nil {
+		err = fmt.Errorf("computing checksum: %w", err)
+		return
+	}
+
+	// Write version
+	bufU32 := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bufU32, 4)
+	if _, err := writer.WriteAt(bufU32, 0); err != nil {
+		return 0, fmt.Errorf("writing header version: %w", err)
+	}
+	written += 4
+
+	metaEntryLen, err := WriteEvent(
+		writer,
+		nil,
+		metaChecksum,
+		4, 0,
+		eventlog.Event{PayloadJSON: metadataJSON},
+	)
+	written += metaEntryLen
+	if err != nil {
+		return written, fmt.Errorf("writing metadata: %w", err)
+	}
+
+	return written, nil
 }

--- a/eventlog/inmem/inmem.go
+++ b/eventlog/inmem/inmem.go
@@ -29,13 +29,28 @@ func newInmemEvent(event eventlog.Event, tm time.Time) inmemEvent {
 
 // Inmem is a volatile in-memory event log
 type Inmem struct {
-	lock  sync.RWMutex
-	store []inmemEvent
+	metadata map[string]string
+	lock     sync.RWMutex
+	store    []inmemEvent
 }
 
 // New returns a new volatile in-memory event log instance
-func New() *Inmem {
-	return &Inmem{}
+func New(metadata map[string]string) *Inmem {
+	return &Inmem{
+		metadata: metadata,
+	}
+}
+
+func (l *Inmem) MetadataLen() int {
+	return len(l.metadata)
+}
+
+func (l *Inmem) ScanMetadata(fn func(field, value string) bool) {
+	for f, v := range l.metadata {
+		if !fn(f, v) {
+			return
+		}
+	}
 }
 
 func (l *Inmem) Version() uint64 {

--- a/frontend/fasthttp/fasthttp_test.go
+++ b/frontend/fasthttp/fasthttp_test.go
@@ -96,7 +96,7 @@ type Setup struct {
 }
 
 func setup(t *testing.T) (s Setup) {
-	s.DB = eventlog.New(inmem.New())
+	s.DB = eventlog.New(inmem.New(map[string]string{"name": "testlog"}))
 	t.Cleanup(func() {
 		if err := s.DB.Close(); err != nil {
 			panic(fmt.Errorf("closing eventlog: %s", err))

--- a/frontend/fasthttp/handleMeta.go
+++ b/frontend/fasthttp/handleMeta.go
@@ -1,0 +1,42 @@
+package fasthttp
+
+import (
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	partEmptyObj       = "{}"
+	partOpen           = `{"`
+	partKVSeparator    = `":"`
+	partFieldSeparator = `","`
+)
+
+// handleMeta handles GET /meta
+func (s *Server) handleMeta(ctx *fasthttp.RequestCtx) error {
+	_, _ = ctx.WriteString(partOpen)
+
+	ln := s.eventLog.MetadataLen()
+	if ln < 1 {
+		_, _ = ctx.WriteString(partEmptyObj)
+	} else {
+		i := 0
+		s.eventLog.ScanMetadata(func(field, value string) bool {
+			_, _ = ctx.WriteString(field)
+			_, _ = ctx.WriteString(partKVSeparator)
+			_, _ = ctx.WriteString(value)
+			i++
+			if i < ln {
+				// Not last
+				_, _ = ctx.WriteString(partFieldSeparator)
+			}
+			return true
+		})
+	}
+
+	_, _ = ctx.WriteString(partCloseBlockText)
+
+	ctx.Response.SetStatusCode(fasthttp.StatusOK)
+	ctx.Response.Header.SetContentType("application/json")
+
+	return nil
+}

--- a/frontend/fasthttp/handleRead.go
+++ b/frontend/fasthttp/handleRead.go
@@ -11,14 +11,14 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-var (
-	partE1             = []byte(`{"time":"`)
-	partE2             = []byte(`","offset":"`)
-	partE3             = []byte(`","label":"`)
-	partE4             = []byte(`","payload":`)
-	partE5             = []byte(`,"next":"`)
-	partCloseBlock     = []byte(`}`)
-	partCloseBlockText = []byte(`"}`)
+const (
+	partE1             = `{"time":"`
+	partE2             = `","offset":"`
+	partE3             = `","label":"`
+	partE4             = `","payload":`
+	partE5             = `,"next":"`
+	partCloseBlock     = `}`
+	partCloseBlockText = `"}`
 )
 
 // handleRead handles GET /log/:offset
@@ -41,18 +41,18 @@ func (s *Server) handleRead(ctx *fasthttp.RequestCtx) error {
 			label []byte,
 			payloadJSON []byte,
 		) error {
-			_, _ = ctx.Write(partE1)
+			_, _ = ctx.WriteString(partE1)
 			buf = time.Unix(int64(timestamp), 0).AppendFormat(buf, time.RFC3339)
 			_, _ = ctx.Write(buf)
 			buf = buf[:0]
 
-			_, _ = ctx.Write(partE2)
+			_, _ = ctx.WriteString(partE2)
 			_, _ = hex.WriteUint64(ctx, offset)
 
-			_, _ = ctx.Write(partE3)
+			_, _ = ctx.WriteString(partE3)
 			_, _ = ctx.Write(label)
 
-			_, _ = ctx.Write(partE4)
+			_, _ = ctx.WriteString(partE4)
 			_, _ = ctx.Write(payloadJSON)
 
 			return nil
@@ -75,11 +75,11 @@ func (s *Server) handleRead(ctx *fasthttp.RequestCtx) error {
 	}
 
 	if nextOffset == 0 {
-		_, _ = ctx.Write(partCloseBlock)
+		_, _ = ctx.WriteString(partCloseBlock)
 	} else {
-		_, _ = ctx.Write(partE5)
+		_, _ = ctx.WriteString(partE5)
 		_, _ = hex.WriteUint64(ctx, nextOffset)
-		_, _ = ctx.Write(partCloseBlockText)
+		_, _ = ctx.WriteString(partCloseBlockText)
 	}
 
 	ctx.Response.SetStatusCode(fasthttp.StatusOK)

--- a/frontend/fasthttp/serve.go
+++ b/frontend/fasthttp/serve.go
@@ -30,6 +30,9 @@ func (s *Server) Serve(ctx *fasthttp.RequestCtx) {
 		case bytes.Equal(p, uriSubscription):
 			// GET /subscription
 			handle = s.handleSubscription
+		case bytes.Equal(p, uriMeta):
+			// GET /meta
+			handle = s.handleMeta
 		}
 	case bytes.Equal(m, methodPost):
 		switch {

--- a/frontend/fasthttp/server.go
+++ b/frontend/fasthttp/server.go
@@ -13,6 +13,7 @@ var (
 	methodGet       = []byte("GET")
 	methodPost      = []byte("POST")
 	uriLog          = []byte("/log/")
+	uriMeta         = []byte("/meta")
 	uriBegin        = []byte("/begin")
 	uriVersion      = []byte("/version")
 	uriSubscription = []byte("/subscription")


### PR DESCRIPTION
Reorganize the CLI by dividing it into commands
"create", "open", "check", "inmem" and "help"
with their respective parameters.
Introduce the "GET /meta" endpoint to the HTTP frontend.
Separate file-based log creation and opening methods.
Refactor parts of the code.